### PR TITLE
Fixes generation of too many jobs

### DIFF
--- a/plurmy/__init__.py
+++ b/plurmy/__init__.py
@@ -162,14 +162,14 @@ class Slurm(object):
                 except:
                     return self._submit_one()
                 # Case where the total number of jobs is > the chunk size
-                if stop - start > chunksize:
-                    quot, rem = divmod(stop-start, chunksize)
-                    arrays = [f'1-{chunksize+1}']
+                if stop - start + 1 > chunksize:
+                    quot, rem = divmod(stop-start+1, chunksize)
+                    arrays = [f'1-{chunksize}']
                     if step:
                         arrays[0] += f'%{step}'
                     arrays = arrays*quot
                     if rem:
-                        remainder = f'1-{rem+1}'
+                        remainder = f'1-{rem}'
                         if step:
                             remainder += f'%{step}'
                         arrays.append(remainder)


### PR DESCRIPTION
I was noticing if autocnet generated X jobs with a certain chunksize we would end up with floor(X/chunksize) too many logs. I think the issue was that the range on a slurm job array is inclusive on both ends. So if you have 50 jobs your start = 1 and stop = 50, but then we would divide 49 by the chunksize. I tested this on an area I was working on and I don't have any extra logs.